### PR TITLE
Increase `exec` timeout to 30 seconds

### DIFF
--- a/index.js
+++ b/index.js
@@ -8,7 +8,7 @@ var sprintf = require('util').format;
 
 module.exports = function(image, output, cb) {
   var cmd = module.exports.cmd(image, output);
-  exec(cmd, {timeout: 10000}, function(e, stdout, stderr) {
+  exec(cmd, {timeout: 30000}, function(e, stdout, stderr) {
     if (e) { return cb(e); }
     if (stderr) { return cb(new Error(stderr)); }
 


### PR DESCRIPTION
Increase the timeout period for `exec` to 30 seconds as a temporarily
fix for ImageMagic converts which are timing out. A more permanent fix
will be to support this through an option function arguments.

Signed-off-by: Hans Kristian Flaatten hans.kristian.flaatten@turistforeningen.no
