### PR TITLE
Use version format from source image as fallback

### DIFF
--- a/index.js
+++ b/index.js
@@ -87,13 +87,8 @@ module.exports.resize = function(crop, version) {
  */
 module.exports.path = function(src, opts) {
   var dir = opts.path || dirname(src);
-  var ext = extname(src);
-  var base = basename(src, ext);
-
-  if (opts.format) {
-    opts.format = opts.format.toLowerCase();
-    ext = '.' + (opts.format !== 'jpeg' ? opts.format : 'jpg');
-  }
+  var base = basename(src, extname(src));
+  var ext = '.' + (opts.format !== 'jpeg' ? opts.format : 'jpg');
 
   return join(dir, opts.prefix + base + opts.suffix + ext);
 };
@@ -118,9 +113,10 @@ module.exports.cmd = function(image, output) {
     var last = (i === output.versions.length-1);
 
     version.quality = version.quality || output.quality || 80;
+    version.format = (version.format || image.format || 'JPG').toLowerCase();
 
     version.path = module.exports.path(image.path, {
-      format: version.format || image.format,
+      format: version.format,
       path: output.path,
       prefix: version.prefix || output.prefix || '',
       suffix: version.suffix || ''

--- a/index.js
+++ b/index.js
@@ -92,7 +92,7 @@ module.exports.path = function(src, opts) {
 
   if (opts.format) {
     opts.format = opts.format.toLowerCase();
-    ext = '.' + opts.format;
+    ext = '.' + (opts.format !== 'jpeg' ? opts.format : 'jpg');
   }
 
   return join(dir, opts.prefix + base + opts.suffix + ext);

--- a/index.js
+++ b/index.js
@@ -91,6 +91,7 @@ module.exports.path = function(src, opts) {
   var base = basename(src, ext);
 
   if (opts.format) {
+    opts.format = opts.format.toLowerCase();
     ext = '.' + opts.format;
   }
 

--- a/index.js
+++ b/index.js
@@ -119,7 +119,7 @@ module.exports.cmd = function(image, output) {
     version.quality = version.quality || output.quality || 80;
 
     version.path = module.exports.path(image.path, {
-      format: version.format,
+      format: version.format || image.format,
       path: output.path,
       prefix: version.prefix || output.prefix || '',
       suffix: version.suffix || ''

--- a/test.js
+++ b/test.js
@@ -32,6 +32,16 @@ describe('resize.path()', function() {
     assert.equal(path, 'foo-bar.jpg');
   });
 
+  it('replaces "jpeg" format with "jpg"', function() {
+    var path = resize.path('./foo', {
+      prefix: '',
+      suffix: '-bar',
+      format: 'JPEG'
+    });
+
+    assert.equal(path, 'foo-bar.jpg');
+  });
+
   it('returns new absolute path with suffix', function() {
     var path = resize.path('/foo/bar/baz.jpg', {prefix: '', suffix: '-bix'});
     assert.equal(path, '/foo/bar/baz-bix.jpg');

--- a/test.js
+++ b/test.js
@@ -137,6 +137,7 @@ describe('resize.cmd()', function() {
   beforeEach(function() {
     image = {
       path: './assets/horizontal.jpg',
+      format: 'JPEG',
       width: 5184,
       height: 2623
     };
@@ -194,6 +195,24 @@ describe('resize.cmd()', function() {
 
     assert.equal(output.versions[0].quality, 30);
     assert.equal(output.versions[1].quality, 99);
+  });
+
+  it('sets image format to each version', function() {
+    image.format = 'PNG';
+    resize.cmd(image, output);
+
+    assert(/.png$/.test(output.versions[0].path));
+    assert(/.png$/.test(output.versions[1].path));
+  });
+
+  it('preserves local version format', function() {
+    image.format = 'PNG';
+    output.versions[1].format = 'JPEG';
+
+    resize.cmd(image, output);
+
+    assert(/.png$/.test(output.versions[0].path));
+    assert(/.jpg$/.test(output.versions[1].path));
   });
 
   it('returns convert command', function() {

--- a/test.js
+++ b/test.js
@@ -22,6 +22,16 @@ describe('resize.path()', function() {
     assert.equal(path, 'foo-bar.png');
   });
 
+  it('lower cases custom image format', function() {
+    var path = resize.path('./foo', {
+      prefix: '',
+      suffix: '-bar',
+      format: 'JPG'
+    });
+
+    assert.equal(path, 'foo-bar.jpg');
+  });
+
   it('returns new absolute path with suffix', function() {
     var path = resize.path('/foo/bar/baz.jpg', {prefix: '', suffix: '-bix'});
     assert.equal(path, '/foo/bar/baz-bix.jpg');

--- a/test.js
+++ b/test.js
@@ -157,7 +157,6 @@ describe('resize.cmd()', function() {
   beforeEach(function() {
     image = {
       path: './assets/horizontal.jpg',
-      format: 'JPEG',
       width: 5184,
       height: 2623
     };

--- a/test.js
+++ b/test.js
@@ -6,70 +6,69 @@ var fs = require('fs');
 var resize = require('./index');
 
 describe('resize.path()', function() {
+  var opts;
+
+  beforeEach(function() {
+    opts = {
+      prefix: '',
+      suffix: '',
+      format: 'jpg'
+    };
+  });
+
   it('returns new relative path with suffix', function() {
-    var path = resize.path('./foo.jpg', {prefix: '', suffix: '-bar'});
+    opts.suffix = '-bar';
+    var path = resize.path('./foo.jpg', opts);
 
     assert.equal(path, 'foo-bar.jpg');
   });
 
   it('returns new relative path with custom format', function() {
-    var path = resize.path('./foo.jpg', {
-      prefix: '',
-      suffix: '-bar',
-      format: 'png'
-    });
+    opts.format = 'png';
+    var path = resize.path('./foo.jpg', opts);
 
-    assert.equal(path, 'foo-bar.png');
+    assert.equal(path, 'foo.png');
   });
 
-  it('lower cases custom image format', function() {
-    var path = resize.path('./foo', {
-      prefix: '',
-      suffix: '-bar',
-      format: 'JPG'
-    });
+  it('returns path for image without extension', function() {
+    var path = resize.path('./foo', opts);
 
-    assert.equal(path, 'foo-bar.jpg');
+    assert.equal(path, 'foo.jpg');
   });
 
-  it('replaces "jpeg" format with "jpg"', function() {
-    var path = resize.path('./foo', {
-      prefix: '',
-      suffix: '-bar',
-      format: 'JPEG'
-    });
+  it('replaces custom format "jpeg" with "jpg"', function() {
+    opts.format = 'jpeg';
+    var path = resize.path('./foo.jpeg', opts);
 
-    assert.equal(path, 'foo-bar.jpg');
+    assert.equal(path, 'foo.jpg');
   });
 
   it('returns new absolute path with suffix', function() {
-    var path = resize.path('/foo/bar/baz.jpg', {prefix: '', suffix: '-bix'});
+    opts.suffix = '-bix';
+    var path = resize.path('/foo/bar/baz.jpg', opts);
+
     assert.equal(path, '/foo/bar/baz-bix.jpg');
   });
 
   it('returns new absolute path with custom format', function() {
-    var path = resize.path('/foo/bar/baz.jpg', {
-      prefix: '',
-      suffix: '-bix',
-      format: 'png'
-    });
+    opts.format = 'png';
+    var path = resize.path('/foo/bar/baz.jpg', opts);
 
-    assert.equal(path, '/foo/bar/baz-bix.png');
+    assert.equal(path, '/foo/bar/baz.png');
   });
 
   it('returns new path with prefix', function() {
-    var path = resize.path('/foo/bar/baz.jpg', {prefix: 'prefix-', suffix: ''});
-    assert.equal(path, '/foo/bar/prefix-baz.jpg');
+    opts.prefix = 'bix-';
+    var path = resize.path('/foo/bar/baz.jpg', opts);
+
+    assert.equal(path, '/foo/bar/bix-baz.jpg');
   });
 
   it('returns new path with custom directory', function() {
-    var path = resize.path('/foo/bar/baz.jpg', {
-      prefix: 'im-',
-      suffix: '',
-      path: '/tmp'
-    });
+    opts.path = '/tmp';
+    var path = resize.path('/foo/bar/baz.jpg', opts);
 
-    assert.equal(path, '/tmp/im-baz.jpg');
+    assert.equal(path, '/tmp/baz.jpg');
   });
 });
 
@@ -232,6 +231,16 @@ describe('resize.cmd()', function() {
 
     assert(/.png$/.test(output.versions[0].path));
     assert(/.jpg$/.test(output.versions[1].path));
+  });
+
+  it('sets default version format', function() {
+    image.format = undefined;
+    image.path = './assets/horizontal';
+
+    resize.cmd(image, output);
+
+    assert(/.jpg/.test(output.versions[0].path));
+    assert(/.jpg/.test(output.versions[1].path));
   });
 
   it('returns convert command', function() {


### PR DESCRIPTION
This PR ensures that resized image versions has an image extension for their output path if not already provided by the `version.format` option. 

``` js
var image = {
  path: './image',
  format: 'JPEG',
  width: 5184,
  height: 2623
};

var output = {
  versions: [{
    suffix: '-full',
    maxHeight: 1920,
    maxWidth: 1920
  },{
    suffix: '-1200',
    maxHeight: 1200,
    maxWidth: 1200,
    aspect: '3:2',
    format: 'PNG'
  }]
};

resize(image, output);

// output.versions[0].format => jpg
// output.versions[0].path   => image-full.jpg
// output.versions[1].format => png
// output.versions[1].path   => image-1200.png
```
