### PR TITLE
fix(exec): make `exec` timeout configurable

### DIFF
--- a/index.js
+++ b/index.js
@@ -8,7 +8,8 @@ var sprintf = require('util').format;
 
 module.exports = function(image, output, cb) {
   var cmd = module.exports.cmd(image, output);
-  exec(cmd, {timeout: 30000}, function(e, stdout, stderr) {
+  var timeout = process.env.IM_TIMEOUT ? parseInt(process.env.IM_TIMEOUT) : 30000
+  exec(cmd, {timeout}, function(e, stdout, stderr) {
     if (e) { return cb(e); }
     if (stderr) { return cb(new Error(stderr)); }
 


### PR DESCRIPTION
I need to increase the timeout when using https://github.com/Turistforeningen/node-s3-uploader, I thought changing the default via process.env is easier than adding a new config variable in both packages